### PR TITLE
avoid 'too many values to unpack'

### DIFF
--- a/lcm_websocket_server/app.py
+++ b/lcm_websocket_server/app.py
@@ -38,7 +38,7 @@ async def run_server(lcm_type_registry: LCMTypeRegistry, lcm_republisher: LCMRep
             websocket: The WebSocket connection
             path: The path of the WebSocket connection
         """
-        ip, port = websocket.remote_address
+        ip, port = websocket.remote_address[:2]
         print(f"Client connected from {ip}:{port} at {path}")
 
         # Create an LCM observer for this client


### PR DESCRIPTION
I faced this:

connection handler failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/websockets/legacy/server.py", line 236, in handler
    await self.ws_handler(self)
  File "/usr/local/lib/python3.11/site-packages/websockets/legacy/server.py", line 1175, in _ws_handler
    return await cast(
           ^^^^^^^^^^^
  File "/Users/carueda/github/mbari-org/lcm-websocket-server/lcm_websocket_server/app.py", line 41, in republish_lcm
    ip, port = websocket.remote_address
    ^^^^^^^^
ValueError: too many values to unpack (expected 2)
probaly caused by my env somehow triggering the use of ipv6 instead of ipv4:

https://websockets.readthedocs.io/en/stable/reference/server.html#websockets.server.WebSocketServerProtocol.remote_address

where, in my case websocket.remote_address is a 4-tuple.

Anyway, as you can see the adjustment here is simple to gracefully handle variations, well, at least to some good extent.