### PR TITLE
avoid 'too many values to unpack'

### DIFF
--- a/lcm_websocket_server/app.py
+++ b/lcm_websocket_server/app.py
@@ -41,7 +41,7 @@ async def run_server(lcm_type_registry: LCMTypeRegistry, lcm_republisher: LCMRep
             websocket: The WebSocket connection
             path: The path of the WebSocket connection
         """
-        ip, port = websocket.remote_address
+        ip, port = websocket.remote_address[:2]
         logger.info(f"Client connected from {ip}:{port} at {path}")
 
         # Create an LCM observer for this client


### PR DESCRIPTION
My bad, I thought I had main completely up-to-date ; )


Anyway, the key reference: https://websockets.readthedocs.io/en/stable/reference/server.html#websockets.server.WebSocketServerProtocol.remote_address

And hopefully this adjustment is a graceful handling of tuple size variations (assuming the first two elements are ip and port, of course).